### PR TITLE
client depend on parent snapshot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.zanata</groupId>
     <artifactId>zanata-parent</artifactId>
-    <version>15</version>
+    <version>16-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 


### PR DESCRIPTION
This is the corresponding fix for parent pom jdk range problem.
See https://github.com/zanata/zanata-parent/pull/5
