### PR TITLE
Make sure skeletons are not overwritting cached files.

### DIFF
--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/PullCommand.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/PullCommand.java
@@ -308,9 +308,9 @@ public class PullCommand extends PushPullCommand<PullOptions> {
 
                             // Write the target document
                             writeTargetDoc(strat, localDocName, locMapping,
-                                doc, targetDoc,
-                                transResponse.getResponseHeaders()
-                                    .getFirst(HttpHeaders.ETAG));
+                                    doc, targetDoc,
+                                    transResponse.getResponseHeaders()
+                                            .getFirst(HttpHeaders.ETAG));
                         }
                     }
 


### PR DESCRIPTION
Skeleton files were being written even when a cached file was not overwritten.
