### PR TITLE
rhbz1157359 - remove extension check when dealing with unqualified sourc...

### DIFF
--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/UnqualifiedSrcDocName.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/UnqualifiedSrcDocName.java
@@ -21,10 +21,7 @@
 
 package org.zanata.client.commands;
 
-import org.apache.commons.io.FilenameUtils;
 import org.zanata.common.ProjectType;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 
 /**
  * Represents document name without extension.
@@ -34,12 +31,11 @@ public class UnqualifiedSrcDocName {
     UnqualifiedSrcDocName(String name) {
         this.name = name;
     }
+
     public static UnqualifiedSrcDocName from(String docName) {
-        String extension = FilenameUtils.getExtension(docName);
-        Preconditions.checkArgument(Strings.isNullOrEmpty(extension),
-                "expect an unqualified document name (without extension)");
         return new UnqualifiedSrcDocName(docName);
     }
+
     public QualifiedSrcDocName toQualifiedDocName(ProjectType projectType) {
         switch (projectType) {
             case Utf8Properties:


### PR DESCRIPTION
We were checking argument that is passed to UnqualifiedSrcDocName to not have extension. But there is really no way to tell. Files may contain "." in it and will be treated as if it's extension. If calling this method inappropriately(unlikely), it will produce bad translation file names. But that's not the end of the world...

To fix https://bugzilla.redhat.com/show_bug.cgi?id=1157359
