### PR TITLE
rhbz1124630 - need to override accept header for some clients to work

### DIFF
--- a/zanata-rest-client/src/main/java/org/zanata/rest/client/ProjectClient.java
+++ b/zanata-rest-client/src/main/java/org/zanata/rest/client/ProjectClient.java
@@ -21,6 +21,8 @@
 
 package org.zanata.rest.client;
 
+import javax.ws.rs.core.MediaType;
+
 import org.zanata.rest.dto.Project;
 import org.zanata.rest.service.ProjectResource;
 import com.sun.jersey.api.client.WebResource;
@@ -50,6 +52,7 @@ public class ProjectClient {
     }
 
     public void put(Project project) {
-        webResource().put(project);
+        webResource().accept(MediaType.WILDCARD_TYPE).put(project);
     }
 }
+

--- a/zanata-rest-client/src/main/java/org/zanata/rest/client/ProjectIterationClient.java
+++ b/zanata-rest-client/src/main/java/org/zanata/rest/client/ProjectIterationClient.java
@@ -23,6 +23,8 @@ package org.zanata.rest.client;
 
 import java.net.URI;
 
+import javax.ws.rs.core.MediaType;
+
 import org.zanata.rest.dto.ProjectIteration;
 import com.sun.jersey.api.client.WebResource;
 
@@ -55,10 +57,11 @@ public class ProjectIterationClient {
     }
 
     public void put(ProjectIteration projectVersion) {
-        webResource().put(projectVersion);
+        webResource().accept(MediaType.WILDCARD_TYPE).put(projectVersion);
     }
 
     public String sampleConfiguration() {
         return webResource().path("config").get(String.class);
     }
 }
+


### PR DESCRIPTION
Very strange. I needed to add accept header to these two resource clients to make it work.
Otherwise the Accept header will be set to "text/html, image/gif, image/jpeg, *" and on the server it will cause an exception at org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java:42 which in result returns a 415 unsupported media type. 

I don't need to do this for other clients. I am very confused but this change fixed it.
