### PR TITLE
rhbz1174516 - enable more flexible file mappings rules in podir project

### DIFF
--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/push/AbstractGettextPushStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/push/AbstractGettextPushStrategy.java
@@ -100,11 +100,13 @@ public abstract class AbstractGettextPushStrategy extends AbstractPushStrategy {
 
     /**
      * Try to find locales based on translation files found on local file
-     * system.
+     * system. It will be called for each source document in a loop.
      *
      * @return a list of locale mapping that potentially has translation files
+     * @param srcDocName
+     *            source document name
      */
-    abstract Collection<LocaleMapping> findLocales();
+    abstract Collection<LocaleMapping> findLocales(String srcDocName);
 
     protected File getTransFile(LocaleMapping locale, String docName) {
         File transFile = new TransFileResolver(getOpts()).getTransFile(
@@ -128,10 +130,10 @@ public abstract class AbstractGettextPushStrategy extends AbstractPushStrategy {
     }
 
     @Override
-    public void visitTranslationResources(String docName, Resource srcDoc,
+    public void visitTranslationResources(String srcDocName, Resource srcDoc,
             TranslationResourcesVisitor callback) throws IOException {
-        for (LocaleMapping locale : findLocales()) {
-            File transFile = getTransFile(locale, docName);
+        for (LocaleMapping locale : findLocales(srcDocName)) {
+            File transFile = getTransFile(locale, srcDocName);
             if (transFile.canRead()) {
                 try (BufferedInputStream bis = new BufferedInputStream(
                         new FileInputStream(transFile))) {

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/push/GettextDirStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/push/GettextDirStrategy.java
@@ -22,23 +22,16 @@
 package org.zanata.client.commands.push;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zanata.client.commands.ConsoleInteractorImpl;
-import org.zanata.client.commands.FileMappingRuleHandler;
-import org.zanata.client.commands.QualifiedSrcDocName;
 import org.zanata.client.commands.TransFileResolver;
 import org.zanata.client.commands.UnqualifiedSrcDocName;
-import org.zanata.client.config.FileMappingRule;
 import org.zanata.client.config.LocaleList;
 import org.zanata.client.config.LocaleMapping;
-import org.zanata.common.ProjectType;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
+
 import com.google.common.collect.Lists;
 
 public class GettextDirStrategy extends AbstractGettextPushStrategy {
@@ -46,7 +39,7 @@ public class GettextDirStrategy extends AbstractGettextPushStrategy {
             .getLogger(GettextDirStrategy.class);
 
     @Override
-    List<LocaleMapping> findLocales() {
+    List<LocaleMapping> findLocales(String srcDocName) {
 
         List<LocaleMapping> localesFoundOnDisk = Lists.newArrayList();
 
@@ -56,9 +49,8 @@ public class GettextDirStrategy extends AbstractGettextPushStrategy {
             return localesFoundOnDisk;
         }
 
-        Set<String> srcDocNames = getSrcDocNames();
         for (LocaleMapping loc : localeListInConfig) {
-            if (hasTranslationFileForLocale(loc, srcDocNames)) {
+            if (hasTranslationFileForLocale(loc, srcDocName)) {
                 localesFoundOnDisk.add(loc);
             } else {
                 log.warn(
@@ -74,24 +66,14 @@ public class GettextDirStrategy extends AbstractGettextPushStrategy {
                             .getPushType());
         }
 
-        return localeListInConfig;
-    }
-
-    @VisibleForTesting
-    protected void setLocalSrcDocNames(Set<String> srcDocNames) {
-        super.localSrcDocNames = srcDocNames;
+        return localesFoundOnDisk;
     }
 
     private boolean hasTranslationFileForLocale(LocaleMapping loc,
-            Set<String> srcDocNames) {
-        for (String srcDocName : srcDocNames) {
-            File transFile = new TransFileResolver(getOpts()).getTransFile(
-                    UnqualifiedSrcDocName.from(srcDocName), loc);
-            if (transFile.exists()) {
-                return true;
-            }
-        }
-        return false;
+            String srcDocName) {
+        File transFile = new TransFileResolver(getOpts()).getTransFile(
+                UnqualifiedSrcDocName.from(srcDocName), loc);
+        return transFile.exists();
     }
 
     @Override

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/push/GettextPushStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/push/GettextPushStrategy.java
@@ -22,7 +22,7 @@ public class GettextPushStrategy extends AbstractGettextPushStrategy {
             .getLogger(GettextPushStrategy.class);
 
     @Override
-    List<LocaleMapping> findLocales() {
+    List<LocaleMapping> findLocales(String srcDocName) {
         // find all .po basenames in this dir and subdirs
         Collection<File> transFilesOnDisk =
                 listFiles(getOpts().getTransDir(), new String[] { "po" }, true);
@@ -34,17 +34,15 @@ public class GettextPushStrategy extends AbstractGettextPushStrategy {
             return Collections.emptyList();
         }
 
-        for (String srcDocName : getSrcDocNames()) {
-            final UnqualifiedSrcDocName unqualifiedSrcDocName =
-                    UnqualifiedSrcDocName.from(srcDocName);
-            List<File> transFilesDestinations =
-                    Lists.transform(localeListInConfig,
-                            new LocaleMappingToTransFile(unqualifiedSrcDocName,
-                                    getOpts()));
-            // we remove all the ones that WILL be mapped and treated as
-            // translation files
-            transFilesOnDisk.removeAll(transFilesDestinations);
-        }
+        final UnqualifiedSrcDocName unqualifiedSrcDocName =
+                UnqualifiedSrcDocName.from(srcDocName);
+        List<File> transFilesDestinations =
+                Lists.transform(localeListInConfig,
+                        new LocaleMappingToTransFile(unqualifiedSrcDocName,
+                                getOpts()));
+        // we remove all the ones that WILL be mapped and treated as
+        // translation files
+        transFilesOnDisk.removeAll(transFilesDestinations);
         // for all remaining po files we give a warning
         for (File transFile : transFilesOnDisk) {
             log.warn(

--- a/zanata-client-commands/src/test/java/org/zanata/client/commands/push/GettextDirStrategyTest.java
+++ b/zanata-client-commands/src/test/java/org/zanata/client/commands/push/GettextDirStrategyTest.java
@@ -24,7 +24,6 @@ package org.zanata.client.commands.push;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -39,7 +38,6 @@ import com.google.common.collect.Sets;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
 import static org.zanata.client.TestUtils.createAndAddLocaleMapping;
 
 public class GettextDirStrategyTest {
@@ -99,8 +97,6 @@ public class GettextDirStrategyTest {
     // rhbz1174516
     @Test
     public void willWorkOnNonStandardTranslationDir() throws IOException {
-        // Given: source document as "foo/message.pot"
-        strategy.setLocalSrcDocNames(Sets.newHashSet("foo/message"));
         opts.setPushType("trans");
         opts.setFileMappingRules(newArrayList(
                 new FileMappingRule(null,
@@ -119,7 +115,7 @@ public class GettextDirStrategyTest {
         tempFileRule
                 .createTransFileRelativeToTransDir("manfoo/zh_Hans/message.po");
 
-        List<LocaleMapping> locales = strategy.findLocales();
+        List<LocaleMapping> locales = strategy.findLocales("foo/message");
 
         assertThat(locales, Matchers.containsInAnyOrder(deMapping, zhMapping));
     }


### PR DESCRIPTION
- when push, podir project can no longer rely on translation files having locale as a directory
