### PR TITLE
Stop api from forcing jersey upgrade

### DIFF
--- a/zanata-client-commands/pom.xml
+++ b/zanata-client-commands/pom.xml
@@ -21,6 +21,16 @@
     <dependency>
       <groupId>org.zanata</groupId>
       <artifactId>zanata-common-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.zanata</groupId>
@@ -41,6 +51,16 @@
     <dependency>
       <groupId>org.zanata</groupId>
       <artifactId>zanata-rest-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.zanata</groupId>

--- a/zanata-rest-client/pom.xml
+++ b/zanata-rest-client/pom.xml
@@ -29,6 +29,16 @@
     <dependency>
       <groupId>org.zanata</groupId>
       <artifactId>zanata-common-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.zanata</groupId>


### PR DESCRIPTION
It's not ideal, but this should fix the compilation error caused by https://github.com/zanata/zanata-api/commit/d8948c917c96b49b6dd135878ae07c07868dcb30.

Note that Fedora 21 is still on Jersey 1.17.1.