### PR TITLE
Add a new parameter includeAutomatedEntry to API getContributionStatics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
   </repositories>
 
   <properties>
-    <zanata.api.version>3.8.0-SNAPSHOT</zanata.api.version>
+    <zanata.api.version>3.9.0-SNAPSHOT</zanata.api.version>
     <zanata.common.version>3.8.0-SNAPSHOT</zanata.common.version>
     <resteasy.version>3.0.11.Final</resteasy.version>
     <jersey.version>1.17.1</jersey.version>

--- a/stub-server/src/main/java/org/zanata/rest/service/MockStatisticsResource.java
+++ b/stub-server/src/main/java/org/zanata/rest/service/MockStatisticsResource.java
@@ -69,7 +69,7 @@ public class MockStatisticsResource implements StatisticsResource {
 
     @Override
     public ContributionStatistics getContributionStatistics(String projectSlug,
-            String versionSlug, String username, String dateRange) {
+            String versionSlug, String username, String dateRange, boolean includeAutomatedEntry) {
         ContributionStatistics contributionStatistics =
                 new ContributionStatistics();
         LocaleStatistics localeStatistics = new LocaleStatistics();

--- a/zanata-rest-client/src/main/java/org/zanata/rest/client/StatisticsResourceClient.java
+++ b/zanata-rest-client/src/main/java/org/zanata/rest/client/StatisticsResourceClient.java
@@ -95,7 +95,7 @@ public class StatisticsResourceClient implements StatisticsResource {
 
     @Override
     public ContributionStatistics getContributionStatistics(String projectSlug,
-            String versionSlug, String username, String dateRange) {
+            String versionSlug, String username, String dateRange, boolean includeAutomatedEntry) {
         WebResource webResource =
                 factory.getClient().resource(baseUri).path("stats")
                         .path("project")
@@ -104,7 +104,8 @@ public class StatisticsResourceClient implements StatisticsResource {
                         .path(versionSlug)
                         .path("contributor")
                         .path(username)
-                        .path(dateRange);
+                        .path(dateRange)
+                        .queryParam("includeAutomatedEntry", String.valueOf(includeAutomatedEntry));
         return webResource.get(ContributionStatistics.class);
     }
 }

--- a/zanata-rest-client/src/test/java/org/zanata/rest/client/StatisticsResourceClientTest.java
+++ b/zanata-rest-client/src/test/java/org/zanata/rest/client/StatisticsResourceClientTest.java
@@ -73,7 +73,7 @@ public class StatisticsResourceClientTest {
     public void testGetContributorStatistics() {
         ContributionStatistics statistics =
                 client.getContributionStatistics("about-fedora", "master",
-                        "pahuang", "2014-10-01..2014-11-10");
+                        "pahuang", "2014-10-01..2014-11-10",false);
         assertThat(statistics, Matchers.hasKey("pahuang"));
     }
 


### PR DESCRIPTION
This is a patch related to https://github.com/zanata/zanata-server/pull/1029.

Add a new parameter to getContributionStatistic API.
The parameter is a boolean type to control whether to include automatic entries of translation into statistic.