### PR TITLE
Update OSX install docs with Homebrew [skip ci]

### DIFF
--- a/docs/installation/osx-installation.md
+++ b/docs/installation/osx-installation.md
@@ -1,6 +1,15 @@
+## With Homebrew
+
+1. Install [Homebrew](http://brew.sh/): `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+  - If you already have Homebrew installed, run `brew update` to pull in the latest formulae.
+2. Install the zanata-client: `brew install zanata-client`
+3. Now you can run `zanata-cli --help` for more options.
+
+## With 0Install
+
 1. Click [here](http://downloads.sourceforge.net/project/zero-install/0install/2.8/ZeroInstall.pkg) to download binary package of [0Install for OS X](http://0install.net/install-osx.html).
 2. Install 0Install: `sudo installer -pkg ZeroInstall.pkg -target`.
-3. Install homebrew: `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+3. Install [Homebrew](http://brew.sh/): `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 4. Install cask: `brew install caskroom/cask/brew-cask`.
 5. Install Java runtime: `brew cask install java`.
 6. Setup alias: `0install -c add zanata-cli http://zanata.org/files/0install/zanata-cli.xml`.


### PR DESCRIPTION
This depends on my PR to homebrew to add the zanata-client formula: https://github.com/Homebrew/homebrew/pull/44515

Once that is in, this PR updates the documentation to use that.  I'm not sure this is the same as what's on the website, so if there's another place I need to update this documentation, please let me know.

Incidentally, when I go to http://zanata.org/help/cli-install/, I no longer see the OSX installation page.  I was pretty sure it used to be there, but I don't see it anymore...did something change?