### PR TITLE
docs(install): add java to client yum install instructions

### DIFF
--- a/docs/installation/linux-installation.md
+++ b/docs/installation/linux-installation.md
@@ -25,7 +25,7 @@ There are two ways to install zanata-client, via `0install` or `yum`.
 
 2. Install package `zanata-cli-bin`
 
-        sudo yum -y install zanata-cli-bin
+        sudo yum -y install zanata-cli-bin java-1.8.0-openjdk
 
 3. It should be done now. Run `zanata-cli --help` for the usage of the client.
 
@@ -70,7 +70,7 @@ There are two ways to install zanata-client, via `0install` or `yum`.
 
 2. Install package `zanata-cli-bin`
 
-        sudo yum -y install zanata-cli-bin
+        sudo yum -y install zanata-cli-bin java-1.8.0-openjdk
 
 3. It should be done now. Run `zanata-cli --help` for the usage of the client.
 


### PR DESCRIPTION
Translators are having issues with both 0install and yum installation on RHEL7. Adding this got one of them working, so adding it to the docs for now.

Targeting `master` on purpose because the jenkins system is not operating and would not merge the changes in a timely manner for translators to use them.