### PR TITLE
Update manual-installation.md to fix symlinking

### DIFF
--- a/docs/installation/manual-installation.md
+++ b/docs/installation/manual-installation.md
@@ -3,8 +3,8 @@ If you want to setup zanata-cli from manually (without 0install):
  1. Navigate to [zanata-cli on Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.zanata%22%20AND%20a%3A%22zanata-cli%22).
  1. Download either `dist.zip` or `dist.tar.gz`.
  1. Extract the contents of the archive to your location of choice.
- 1. Create a symbolic link to the `zanata-cli` script in the bin directory of the extracted archive. e.g. from the archive directory, run `sudo ln -s bin/zanata-cli  /usr/local/bin/zanata-cli`.
- 1. (optional) you can also enable tab-autocomplete for the client if you use bash as your terminal shell. This can be done by copying or linking the `zanata-cli-completion` script from the bin directory to `/etc/bash_completion.d/`. e.g. `ln -s bin/zanata-cli-completion /etc/bash_completion.d/zanata-cli-completion`.
+ 1. Create a symbolic link to the `zanata-cli` script in the bin directory of the extracted archive. e.g. from the archive directory, run `sudo ln -s --relative bin/zanata-cli  /usr/local/bin/zanata-cli`.
+ 1. (optional) you can also enable tab-autocomplete for the client if you use bash as your terminal shell. This can be done by copying or linking the `zanata-cli-completion` script from the bin directory to `/etc/bash_completion.d/`. e.g. `ln -s --relative bin/zanata-cli-completion /etc/bash_completion.d/zanata-cli-completion`.
  
  
 ### Nightly Builds


### PR DESCRIPTION
Added `--relative` option to instructions for symbolic linking.
`ln` needs this option to create working symbolic links when a non-absolute target path is provided, as in the current examples.

Same change as in #95, but to a different branch as per @aeng 's request.