### PR TITLE
Rename QualifiedSrcDocName and UnqualifiedSrcDocName

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ cache:
 
 language: java
 
+before_install:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
+  - unzip -qq apache-maven-3.3.9-bin.zip
+  - export M2_HOME=$PWD/apache-maven-3.3.9
+  - export PATH=$M2_HOME/bin:$PATH
+
 # Use the 'true' command to avoid up-front dependency fetching, for faster builds
 # See http://docs.travis-ci.com/user/languages/java/#Dependency-Management
 install: /bin/true

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/DocNameWithExt.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/DocNameWithExt.java
@@ -26,24 +26,24 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 /**
- * Represents document name with extension.
+ * Represents a source document name with extension.
  */
-public class QualifiedSrcDocName {
+public class DocNameWithExt {
     private final String fullName;
     private final String extension;
 
-    QualifiedSrcDocName(String fullName) {
+    DocNameWithExt(String fullName) {
         this.fullName = fullName;
         extension = FilenameUtils.getExtension(fullName).toLowerCase();
     }
-    public static QualifiedSrcDocName from(String qualifiedName) {
-        String extension = FilenameUtils.getExtension(qualifiedName);
+    public static DocNameWithExt from(String filename) {
+        String extension = FilenameUtils.getExtension(filename);
         Preconditions.checkArgument(!Strings.isNullOrEmpty(extension),
-                "expect a qualified document name (with extension)");
-        return new QualifiedSrcDocName(qualifiedName);
+                "expected a full filename (with extension)");
+        return new DocNameWithExt(filename);
     }
-    public static QualifiedSrcDocName from(String unqualifiedName, String extension) {
-        return new QualifiedSrcDocName(unqualifiedName + "." + extension);
+    public static DocNameWithExt from(String docNameWithoutExt, String extension) {
+        return new DocNameWithExt(docNameWithoutExt + "." + extension);
     }
 
     public String getFullName() {

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/DocNameWithoutExt.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/DocNameWithoutExt.java
@@ -24,33 +24,33 @@ package org.zanata.client.commands;
 import org.zanata.common.ProjectType;
 
 /**
- * Represents document name without extension.
+ * Represents a source document name without extension.
  */
-public class UnqualifiedSrcDocName {
+public class DocNameWithoutExt {
     private final String name;
-    UnqualifiedSrcDocName(String name) {
+    DocNameWithoutExt(String name) {
         this.name = name;
     }
 
-    public static UnqualifiedSrcDocName from(String docName) {
-        return new UnqualifiedSrcDocName(docName);
+    public static DocNameWithoutExt from(String docName) {
+        return new DocNameWithoutExt(docName);
     }
 
-    public QualifiedSrcDocName toQualifiedDocName(ProjectType projectType) {
+    public DocNameWithExt toDocNameWithExt(ProjectType projectType) {
         switch (projectType) {
             case Utf8Properties:
             case Properties:
-                return QualifiedSrcDocName
+                return DocNameWithExt
                         .from(name, "properties");
             case Gettext:
             case Podir:
-                return QualifiedSrcDocName.from(name, "pot");
+                return DocNameWithExt.from(name, "pot");
             case Xliff:
             case Xml:
-                return QualifiedSrcDocName.from(name, "xml");
+                return DocNameWithExt.from(name, "xml");
             case File:
-                throw new IllegalArgumentException("You can not using unqualified document name in file type project");
+                throw new IllegalArgumentException("You cannot use document name without extension with FILE project type");
         }
-        throw new IllegalStateException("Can not convert unqualified document name for this project type: " + projectType);
+        throw new IllegalStateException("Cannot determine file extension for this project type: " + projectType);
     }
 }

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/FileMappingRuleHandler.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/FileMappingRuleHandler.java
@@ -75,32 +75,32 @@ public class FileMappingRuleHandler {
     /**
      * Check whether the parsed rule is applicable to a source document.
      *
-     * @param qualifiedSrcDocName
+     * @param docNameWithExt
      *            source document name with extension
      * @return true if this parsed rule is applicable
      */
-    public boolean isApplicable(QualifiedSrcDocName qualifiedSrcDocName) {
+    public boolean isApplicable(DocNameWithExt docNameWithExt) {
         if (Strings.isNullOrEmpty(mappingRule.getPattern())) {
-            return matchFileExtensionWithProjectType(qualifiedSrcDocName);
+            return matchFileExtensionWithProjectType(docNameWithExt);
         }
         PathMatcher matcher =
             FileSystems.getDefault().getPathMatcher("glob:" + mappingRule.getPattern());
-        // this will help when qualifiedSrcDocName has just file name i.e.
+        // this will help when docNameWithExt has just file name i.e.
         // test.odt whereas pattern is defined as **/*.odt
         File srcFile =
                 new File(opts.getSrcDir(),
-                        qualifiedSrcDocName.getFullName());
+                        docNameWithExt.getFullName());
         log.debug("trying to match pattern: {} to file: {}",
                 mappingRule.getPattern(), srcFile.getPath());
         return matcher.matches(Paths.get(srcFile.getPath()));
     }
 
     private boolean matchFileExtensionWithProjectType(
-            QualifiedSrcDocName qualifiedSrcDocName) {
+            DocNameWithExt docNameWithExt) {
         List<DocumentType> documentTypes = projectType.getSourceFileTypes();
         for (DocumentType docType: documentTypes) {
             if (docType.getSourceExtensions().contains(
-                    qualifiedSrcDocName.getExtension())) {
+                    docNameWithExt.getExtension())) {
                 return true;
             }
         }
@@ -110,17 +110,17 @@ public class FileMappingRuleHandler {
     /**
      * Apply the rule and return relative path of the translation file.
      *
-     * @param qualifiedSrcDocName
+     * @param docNameWithExt
      *            source document name with extension
      * @param localeMapping
      *            locale mapping
      * @return relative path (relative to trans-dir) for the translation file
      */
     public String getRelativeTransFilePathForSourceDoc(
-            QualifiedSrcDocName qualifiedSrcDocName,
+            DocNameWithExt docNameWithExt,
             @Nonnull LocaleMapping localeMapping, Optional<String> translationFileExtension) {
         EnumMap<Placeholders, String> map =
-                parseToMap(qualifiedSrcDocName.getFullName(), localeMapping, translationFileExtension);
+                parseToMap(docNameWithExt.getFullName(), localeMapping, translationFileExtension);
 
         String transFilePath = mappingRule.getRule();
         for (Map.Entry<Placeholders, String> entry : map.entrySet()) {

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/TransFileResolver.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/TransFileResolver.java
@@ -77,22 +77,22 @@ public class TransFileResolver {
      * Determines where to store the translation file for a given source
      * document and locale mapping.
      *
-     * @param qualifiedSrcDocName
+     * @param docNameWithExt
      *            source document name with extension
      * @param localeMapping
      *            locale mapping
      * @return translation destination
      */
-    public File resolveTransFile(QualifiedSrcDocName qualifiedSrcDocName,
+    public File resolveTransFile(DocNameWithExt docNameWithExt,
             LocaleMapping localeMapping, Optional<String> translationFileExtension) {
         Optional<File> fileOptional =
-                tryGetTransFileFromProjectMappingRules(qualifiedSrcDocName,
+                tryGetTransFileFromProjectMappingRules(docNameWithExt,
                         localeMapping, translationFileExtension);
         if (fileOptional.isPresent()) {
             return fileOptional.get();
         } else {
             ProjectType projectType = getProjectType();
-            return getDefaultTransFileFromProjectType(qualifiedSrcDocName,
+            return getDefaultTransFileFromProjectType(docNameWithExt,
                     localeMapping, projectType, translationFileExtension);
         }
     }
@@ -101,17 +101,17 @@ public class TransFileResolver {
      * Determines where to store the translation file for a given source
      * document and locale mapping.
      *
-     * @param unqualifiedSrcDocName
+     * @param docNameWithoutExt
      *            source document name without extension
      * @param localeMapping
      *            locale mapping
      * @return translation destination
      */
-    public File getTransFile(UnqualifiedSrcDocName unqualifiedSrcDocName,
+    public File getTransFile(DocNameWithoutExt docNameWithoutExt,
             LocaleMapping localeMapping) {
-        QualifiedSrcDocName qualifiedSrcDocName =
-                unqualifiedSrcDocName.toQualifiedDocName(getProjectType());
-        return resolveTransFile(qualifiedSrcDocName, localeMapping,
+        DocNameWithExt docNameWithExt =
+                docNameWithoutExt.toDocNameWithExt(getProjectType());
+        return resolveTransFile(docNameWithExt, localeMapping,
             Optional.<String>absent());
     }
 
@@ -125,28 +125,28 @@ public class TransFileResolver {
     }
 
     private File getDefaultTransFileFromProjectType(
-            QualifiedSrcDocName qualifiedSrcDocName, LocaleMapping localeMapping,
+            DocNameWithExt docNameWithExt, LocaleMapping localeMapping,
             ProjectType projectType, Optional<String> translationFileExtension) {
         FileMappingRule rule = PROJECT_TYPE_FILE_MAPPING_RULES.get(projectType);
         checkState(rule != null, get("no.default.mapping"), projectType);
         String relativePath = new FileMappingRuleHandler(rule, projectType, opts)
-                .getRelativeTransFilePathForSourceDoc(qualifiedSrcDocName,
+                .getRelativeTransFilePathForSourceDoc(docNameWithExt,
                         localeMapping, translationFileExtension);
         return new File(opts.getTransDir(), relativePath);
     }
 
     private Optional<File> tryGetTransFileFromProjectMappingRules(
-            QualifiedSrcDocName qualifiedSrcDocName, LocaleMapping localeMapping,
+            DocNameWithExt docNameWithExt, LocaleMapping localeMapping,
             Optional<String> translationFileExtension) {
         List<FileMappingRule> fileMappingRules = opts.getFileMappingRules();
         // TODO may need to sort the rules. put rules without pattern to last
         for (FileMappingRule rule : fileMappingRules) {
             FileMappingRuleHandler handler = new FileMappingRuleHandler(rule,
                     getProjectType(), opts);
-            if (handler.isApplicable(qualifiedSrcDocName)) {
+            if (handler.isApplicable(docNameWithExt)) {
                 String relativePath = handler
                         .getRelativeTransFilePathForSourceDoc(
-                                qualifiedSrcDocName,
+                                docNameWithExt,
                                 localeMapping, translationFileExtension);
                 return Optional.of(new File(opts.getTransDir(), relativePath));
             }
@@ -154,7 +154,7 @@ public class TransFileResolver {
         if (fileMappingRules.size() > 0) {
             log.warn(
                     "None of the file mapping rule is applicable for {}. Please make sure your mapping is correct.",
-                    qualifiedSrcDocName.getFullName());
+                    docNameWithExt.getFullName());
         }
         return Optional.absent();
     }

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/init/TransConfigPrompt.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/init/TransConfigPrompt.java
@@ -26,10 +26,9 @@ import java.util.Set;
 import org.apache.commons.io.FilenameUtils;
 import org.zanata.client.commands.ConfigurableProjectOptions;
 import org.zanata.client.commands.ConsoleInteractor;
-import org.zanata.client.commands.OptionsUtil;
-import org.zanata.client.commands.QualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithExt;
 import org.zanata.client.commands.TransFileResolver;
-import org.zanata.client.commands.UnqualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithoutExt;
 import org.zanata.client.commands.pull.PullOptions;
 import org.zanata.client.commands.pull.PullOptionsImpl;
 import org.zanata.client.config.LocaleList;
@@ -168,7 +167,7 @@ class TransConfigPrompt {
             Optional<String> translationFileExtension =
                     Optional.fromNullable(targetFileExt);
             File file = transFileResolver.resolveTransFile(
-                    QualifiedSrcDocName.from(srcDoc),
+                    DocNameWithExt.from(srcDoc),
                     localeMapping, translationFileExtension);
             return file.getPath();
         }
@@ -185,7 +184,7 @@ class TransConfigPrompt {
         public String getTransFileToWrite(String srcDoc,
                 LocaleMapping localeMapping) {
             File transFile = transFileResolver.getTransFile(
-                    UnqualifiedSrcDocName.from(srcDoc), localeMapping);
+                    DocNameWithoutExt.from(srcDoc), localeMapping);
             return transFile.getPath();
         }
     }

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/AbstractPullStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/AbstractPullStrategy.java
@@ -5,7 +5,7 @@ import org.zanata.client.config.LocaleMapping;
 
 import java.io.File;
 
-import org.zanata.client.commands.UnqualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithoutExt;
 
 public abstract class AbstractPullStrategy implements PullStrategy {
     private final PullOptions opts;
@@ -27,6 +27,6 @@ public abstract class AbstractPullStrategy implements PullStrategy {
     public File getTransFileToWrite(String docName,
         LocaleMapping localeMapping) {
         return new TransFileResolver(getOpts()).getTransFile(
-            UnqualifiedSrcDocName.from(docName), localeMapping);
+            DocNameWithoutExt.from(docName), localeMapping);
     }
 }

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/RawPullStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/RawPullStrategy.java
@@ -28,7 +28,7 @@ import java.io.OutputStream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.zanata.client.commands.QualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithExt;
 import org.zanata.client.commands.TransFileResolver;
 import org.zanata.client.config.LocaleMapping;
 import org.zanata.util.PathUtil;
@@ -71,7 +71,7 @@ public class RawPullStrategy {
                     + localDocName);
         }
         File file = new TransFileResolver(opts).resolveTransFile(
-            QualifiedSrcDocName.from(localDocName),
+            DocNameWithExt.from(localDocName),
             localeMapping, translationFileExtension);
         logAndStreamToFile(transFile, file);
     }

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/push/AbstractGettextPushStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/push/AbstractGettextPushStrategy.java
@@ -36,7 +36,7 @@ import com.google.common.collect.ImmutableList;
 import org.xml.sax.InputSource;
 import org.zanata.adapter.po.PoReader2;
 import org.zanata.client.commands.TransFileResolver;
-import org.zanata.client.commands.UnqualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithoutExt;
 import org.zanata.client.commands.push.PushCommand.TranslationResourcesVisitor;
 import org.zanata.client.config.LocaleMapping;
 import org.zanata.common.LocaleId;
@@ -110,7 +110,7 @@ public abstract class AbstractGettextPushStrategy extends AbstractPushStrategy {
 
     protected File getTransFile(LocaleMapping locale, String docName) {
         File transFile = new TransFileResolver(getOpts()).getTransFile(
-                UnqualifiedSrcDocName.from(docName), locale);
+                DocNameWithoutExt.from(docName), locale);
         return transFile;
     }
 

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/push/GettextDirStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/push/GettextDirStrategy.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zanata.client.commands.ConsoleInteractorImpl;
 import org.zanata.client.commands.TransFileResolver;
-import org.zanata.client.commands.UnqualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithoutExt;
 import org.zanata.client.config.LocaleList;
 import org.zanata.client.config.LocaleMapping;
 
@@ -72,7 +72,7 @@ public class GettextDirStrategy extends AbstractGettextPushStrategy {
     private boolean hasTranslationFileForLocale(LocaleMapping loc,
             String srcDocName) {
         File transFile = new TransFileResolver(getOpts()).getTransFile(
-                UnqualifiedSrcDocName.from(srcDocName), loc);
+                DocNameWithoutExt.from(srcDocName), loc);
         return transFile.exists();
     }
 

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/push/GettextPushStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/push/GettextPushStrategy.java
@@ -10,7 +10,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zanata.client.commands.TransFileResolver;
-import org.zanata.client.commands.UnqualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithoutExt;
 import org.zanata.client.config.LocaleList;
 import org.zanata.client.config.LocaleMapping;
 
@@ -34,11 +34,11 @@ public class GettextPushStrategy extends AbstractGettextPushStrategy {
             return Collections.emptyList();
         }
 
-        final UnqualifiedSrcDocName unqualifiedSrcDocName =
-                UnqualifiedSrcDocName.from(srcDocName);
+        final DocNameWithoutExt docNameWithoutExt =
+                DocNameWithoutExt.from(srcDocName);
         List<File> transFilesDestinations =
                 Lists.transform(localeListInConfig,
-                        new LocaleMappingToTransFile(unqualifiedSrcDocName,
+                        new LocaleMappingToTransFile(docNameWithoutExt,
                                 getOpts()));
         // we remove all the ones that WILL be mapped and treated as
         // translation files
@@ -54,18 +54,18 @@ public class GettextPushStrategy extends AbstractGettextPushStrategy {
 
     private static class LocaleMappingToTransFile implements
             Function<LocaleMapping, File> {
-        private final UnqualifiedSrcDocName unqualifiedSrcDocName;
+        private final DocNameWithoutExt docNameWithoutExt;
         private TransFileResolver transFileResolver;
 
         public LocaleMappingToTransFile(
-                UnqualifiedSrcDocName unqualifiedSrcDocName, PushOptions opts) {
-            this.unqualifiedSrcDocName = unqualifiedSrcDocName;
+                DocNameWithoutExt docNameWithoutExt, PushOptions opts) {
+            this.docNameWithoutExt = docNameWithoutExt;
             transFileResolver = new TransFileResolver(opts);
         }
 
         @Override
         public File apply(LocaleMapping localeMapping) {
-            return transFileResolver.getTransFile(unqualifiedSrcDocName,
+            return transFileResolver.getTransFile(docNameWithoutExt,
                     localeMapping);
         }
     }

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/push/PropertiesStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/push/PropertiesStrategy.java
@@ -29,12 +29,11 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FilenameUtils;
 import org.zanata.adapter.properties.PropReader;
 import org.zanata.adapter.properties.PropWriter;
 import org.zanata.client.commands.TransFileResolver;
-import org.zanata.client.commands.UnqualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithoutExt;
 import org.zanata.client.commands.push.PushCommand.TranslationResourcesVisitor;
 import org.zanata.client.config.LocaleMapping;
 import org.zanata.common.ContentState;
@@ -126,7 +125,7 @@ public class PropertiesStrategy extends AbstractPushStrategy {
             RuntimeException {
         for (LocaleMapping locale : getOpts().getLocaleMapList()) {
             File transFile = new TransFileResolver(getOpts()).getTransFile(
-                    UnqualifiedSrcDocName.from(docName),
+                    DocNameWithoutExt.from(docName),
                     locale);
             if (transFile.exists()) {
                 TranslationsResource targetDoc =

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/push/RawPushStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/push/RawPushStrategy.java
@@ -24,7 +24,7 @@ import java.io.File;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.zanata.client.commands.QualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithExt;
 import org.zanata.client.commands.TransFileResolver;
 import org.zanata.client.config.LocaleMapping;
 
@@ -64,7 +64,7 @@ public class RawPushStrategy extends AbstractCommonPushStrategy<PushOptions> {
         }
         for (LocaleMapping localeMapping : getOpts().getLocaleMapList()) {
             File translationFile = new TransFileResolver(getOpts())
-                    .resolveTransFile(QualifiedSrcDocName.from(
+                    .resolveTransFile(DocNameWithExt.from(
                             sourceDocument), localeMapping, translationExtension);
 
             if (translationFile.canRead()) {

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/push/XliffStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/push/XliffStrategy.java
@@ -12,7 +12,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.zanata.adapter.xliff.XliffReader;
 import org.zanata.client.commands.TransFileResolver;
-import org.zanata.client.commands.UnqualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithoutExt;
 import org.zanata.client.commands.push.PushCommand.TranslationResourcesVisitor;
 import org.zanata.client.config.LocaleMapping;
 import org.zanata.common.LocaleId;
@@ -84,7 +84,7 @@ public class XliffStrategy extends AbstractPushStrategy {
             TranslationResourcesVisitor visitor) throws FileNotFoundException {
         for (LocaleMapping locale : getOpts().getLocaleMapList()) {
             File transFile = new TransFileResolver(getOpts()).getTransFile(
-                    UnqualifiedSrcDocName.from(docName),
+                    DocNameWithoutExt.from(docName),
                     locale);
             if (transFile.exists()) {
                 TranslationsResource targetDoc =

--- a/zanata-client-commands/src/main/java/org/zanata/client/commands/push/XmlStrategy.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/commands/push/XmlStrategy.java
@@ -34,7 +34,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.io.FilenameUtils;
 import org.zanata.client.commands.TransFileResolver;
-import org.zanata.client.commands.UnqualifiedSrcDocName;
+import org.zanata.client.commands.DocNameWithoutExt;
 import org.zanata.client.commands.push.PushCommand.TranslationResourcesVisitor;
 import org.zanata.client.config.LocaleMapping;
 import org.zanata.rest.StringSet;
@@ -105,7 +105,7 @@ public class XmlStrategy extends AbstractPushStrategy {
         try {
             for (LocaleMapping locale : getOpts().getLocaleMapList()) {
                 File transFile = new TransFileResolver(getOpts()).getTransFile(
-                        UnqualifiedSrcDocName.from(docName),
+                        DocNameWithoutExt.from(docName),
                         locale);
                 if (transFile.exists()) {
                     TranslationsResource targetDoc =

--- a/zanata-client-commands/src/main/java/org/zanata/client/config/FileMappingRule.java
+++ b/zanata-client-commands/src/main/java/org/zanata/client/config/FileMappingRule.java
@@ -21,6 +21,8 @@
 
 package org.zanata.client.config;
 
+import org.zanata.client.commands.DocNameWithExt;
+
 import java.io.Serializable;
 import javax.xml.bind.annotation.XmlAccessOrder;
 import javax.xml.bind.annotation.XmlAccessorOrder;
@@ -66,7 +68,7 @@ public class FileMappingRule implements Serializable {
     /**
      * If pattern is missing, this rule will be applied to matching file types.
      *
-     * @see org.zanata.client.commands.FileMappingRuleHandler#isApplicable(org.zanata.client.commands.QualifiedSrcDocName)
+     * @see org.zanata.client.commands.FileMappingRuleHandler#isApplicable(DocNameWithExt)
      */
     public FileMappingRule(String rule) {
         this.rule = rule;

--- a/zanata-client-commands/src/test/java/org/zanata/client/commands/FileMappingRuleHandlerTest.java
+++ b/zanata-client-commands/src/test/java/org/zanata/client/commands/FileMappingRuleHandlerTest.java
@@ -78,7 +78,7 @@ public class FileMappingRuleHandlerTest {
                                 "{path}/{locale_with_underscore}.po"),
                         ProjectType.Gettext, opts);
         assertThat(handler.getRelativeTransFilePathForSourceDoc(
-                QualifiedSrcDocName.from("message.pot"),
+                DocNameWithExt.from("message.pot"),
                 new LocaleMapping("zh"), Optional.<String>absent()), Matchers.equalTo("zh.po"));
     }
 
@@ -87,12 +87,12 @@ public class FileMappingRuleHandlerTest {
         FileMappingRuleHandler handler = new FileMappingRuleHandler(
             new FileMappingRule("**/*", rule), projectType, opts);
         return handler.getRelativeTransFilePathForSourceDoc(
-                QualifiedSrcDocName.from(sourceFile),
+                DocNameWithExt.from(sourceFile),
                 new LocaleMapping(locale), Optional.<String>absent());
     }
 
     @Test
-    public void canGetPartsFromQualifiedDocName() {
+    public void canGetPartsFromFullFilename() {
         EnumMap<Placeholders, String> map =
                 FileMappingRuleHandler.parseToMap("foo/message.pot",
                         new LocaleMapping("zh-CN", "zh-Hans"), Optional.<String>absent());
@@ -104,7 +104,7 @@ public class FileMappingRuleHandlerTest {
     }
 
     @Test
-    public void canGetPartsFromQualifiedDocName2() {
+    public void canGetPartsFromFullFilename2() {
         EnumMap<Placeholders, String> map =
             FileMappingRuleHandler.parseToMap("foo/message.pot",
                 new LocaleMapping("zh-CN", "zh-Hans"), Optional.of("po"));
@@ -123,12 +123,12 @@ public class FileMappingRuleHandlerTest {
                         "{locale}/{filename}.{extension}"), ProjectType.File,
                 opts);
         assertThat(handler.isApplicable(
-                QualifiedSrcDocName.from("test/doc.odt")), equalTo(true));
+                DocNameWithExt.from("test/doc.odt")), equalTo(true));
         assertThat(handler.isApplicable(
-                QualifiedSrcDocName.from("test/doc.pot")), equalTo(false));
+                DocNameWithExt.from("test/doc.pot")), equalTo(false));
         assertThat(handler.isApplicable(
-                QualifiedSrcDocName.from("doc.pot")), equalTo(false));
+                DocNameWithExt.from("doc.pot")), equalTo(false));
         assertThat(handler.isApplicable(
-                QualifiedSrcDocName.from("doc.odt")), equalTo(true));
+                DocNameWithExt.from("doc.odt")), equalTo(true));
     }
 }

--- a/zanata-client-commands/src/test/java/org/zanata/client/commands/TransFileResolverTest.java
+++ b/zanata-client-commands/src/test/java/org/zanata/client/commands/TransFileResolverTest.java
@@ -35,14 +35,14 @@ public class TransFileResolverTest {
             new FileMappingRule("**/*.properties",
                 "{path}/{filename}_{locale_with_underscore}.{extension}")));
         File gettext =
-            resolver.resolveTransFile(QualifiedSrcDocName.from(
+            resolver.resolveTransFile(DocNameWithExt.from(
                     "gcc/po/gcc.pot"), new LocaleMapping("de-DE"), Optional
                 .<String>absent());
 
         assertThat(gettext.getPath(), equalTo("./gcc/po/de_DE.po"));
 
         File prop = resolver
-            .resolveTransFile(QualifiedSrcDocName.from(
+            .resolveTransFile(DocNameWithExt.from(
                             "src/main/resources/messages.properties"),
                     new LocaleMapping("zh"), Optional.<String>absent());
         assertThat(prop.getPath(), equalTo(
@@ -54,7 +54,7 @@ public class TransFileResolverTest {
         opts.setTransDir(new File("."));
         opts.setProjectType("file");
         File noMatching = resolver
-                .resolveTransFile(QualifiedSrcDocName.from(
+                .resolveTransFile(DocNameWithExt.from(
                         "doc/marketing.odt"), new LocaleMapping("ja"), Optional.<String>absent());
         assertThat(noMatching.getPath(), equalTo("./ja/doc/marketing.odt"));
     }


### PR DESCRIPTION
Qualified doc name already has a meaning in the client: a document name
with module prefix, if any. Unqualified doc name is the document within
a module. (If Maven multi-modules aren't used, qualified and
unqualified doc name are the same.)